### PR TITLE
Add triming of the URI in the HTTPRequest class

### DIFF
--- a/src/main/java/com/ericsson/eiffelcommons/utils/HttpRequest.java
+++ b/src/main/java/com/ericsson/eiffelcommons/utils/HttpRequest.java
@@ -102,6 +102,7 @@ public class HttpRequest {
      * @param baseUrl
      */
     public HttpRequest setBaseUrl(String baseUrl) {
+        baseUrl = trimBaseUrl(baseUrl);
         this.baseUrl = baseUrl;
         return this;
     }
@@ -212,14 +213,54 @@ public class HttpRequest {
      * @throws ClientProtocolException
      */
     public ResponseEntity performRequest() throws URISyntaxException, ClientProtocolException, IOException {
-        URIBuilder builder = new URIBuilder(baseUrl + endpoint);
+        URIBuilder builder = createURIBuilder();
+        builder = addParametersToURIBuilder(builder);
 
+        request.setURI(builder.build());
+        return executor.executeRequest(request);
+    }
+
+    /**
+     * Function that adds parameters to the URIBuilder
+     *
+     * @param URIBuilder
+     * @return URIBuilder
+     */
+    private URIBuilder addParametersToURIBuilder(URIBuilder builder) {
         if (!params.isEmpty()) {
             for (Map.Entry<String, String> entry : params.entrySet()) {
                 builder.addParameter(entry.getKey(), entry.getValue());
             }
         }
-        request.setURI(builder.build());
-        return executor.executeRequest(request);
+
+        return builder;
+    }
+
+    /**
+     * Function that creates the URI from the baseUrl and endpoint
+     *
+     * @param
+     * @return URIBuilder
+     * @throws URISyntaxException
+     */
+    private URIBuilder createURIBuilder() throws URISyntaxException {
+        if(endpoint.startsWith("/")) {
+            return new URIBuilder(baseUrl + endpoint);
+        } else {
+            return new URIBuilder(baseUrl + "/" + endpoint);
+        }
+    }
+
+    /**
+     * Function that trims the base url for trailing slashes
+     *
+     * @return HttpRequest
+     */
+    private String trimBaseUrl(String baseUrl) {
+        if(baseUrl.endsWith("/")) {
+            baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
+        }
+
+        return baseUrl;
     }
 }

--- a/src/test/java/com/ericsson/eiffelcommons/Utilstest/HttpRequestTest.java
+++ b/src/test/java/com/ericsson/eiffelcommons/Utilstest/HttpRequestTest.java
@@ -1,0 +1,42 @@
+package com.ericsson.eiffelcommons.Utilstest;
+
+import static org.junit.Assert.assertEquals;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+import org.apache.http.client.utils.URIBuilder;
+import org.junit.Test;
+
+import com.ericsson.eiffelcommons.utils.HttpRequest;
+import com.ericsson.eiffelcommons.utils.HttpRequest.HttpMethod;
+
+public class HttpRequestTest {
+    @Test
+    public void testBuildingOfURI() throws NoSuchFieldException, SecurityException, IllegalAccessException, IllegalArgumentException, InvocationTargetException, NoSuchMethodException {
+        String expectedURI = "http://something.com/testing/test/";
+        HttpRequest request= new HttpRequest(HttpMethod.POST);
+        Method method = request.getClass().getDeclaredMethod("createURIBuilder");
+        method.setAccessible(true);
+
+        request.setBaseUrl("http://something.com");
+        request.setEndpoint("/testing/test/");
+        URIBuilder builder = (URIBuilder) method.invoke(request);
+        assertEquals(expectedURI, builder.toString());
+
+        request.setBaseUrl("http://something.com/");
+        request.setEndpoint("/testing/test/");
+        builder = (URIBuilder) method.invoke(request);
+        assertEquals(expectedURI, builder.toString());
+
+        request.setBaseUrl("http://something.com/");
+        request.setEndpoint("testing/test/");
+        builder = (URIBuilder) method.invoke(request);
+        assertEquals(expectedURI, builder.toString());
+
+        request.setBaseUrl("http://something.com");
+        request.setEndpoint("testing/test/");
+        builder = (URIBuilder) method.invoke(request);
+        assertEquals(expectedURI, builder.toString());
+    }
+}


### PR DESCRIPTION
### Description of the Change
<!-- We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the sources addressed by this PR recently, so please walk us through the concepts. -->
Before this change, setting a baseUrl ending with a "/" and seting a endpoint beginning with a "/" would result in "//" in the url. This change will trim the url so it doesn't matter if you add trailing slash on the baseurl or not as well as the leading slash on the endpoint.
### Alternate Designs
<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
<!-- What benefits will be realized by the change? -->
The user of the HTTPRequest object won't need to remember if a trailing "/" was used or not. It could easily become problems in bigger products without this.
### Possible Drawbacks
<!-- What are the possible side-effects or negative impacts of the change? -->
If the user for some reason wants to use "//" between the baseurl and endpoint it won't work anymore. However, it is not something that should be used. According to[RFC 2396](https://stackoverflow.com/questions/10161177/url-with-multiple-forward-slashes-does-it-break-anything) it seems like path segments are separated by "/" only.

https://stackoverflow.com/questions/20523318/is-a-url-with-in-the-path-section-valid

### Sign-off
<!-- Sign the below certificate of origin, using your full name and e-mail address. -->
<!-- The certificate is copied from https://developercertificate.org/ -->

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: <!-- <Your full name> <your-email@example.org> -->
Erik Edling erik.edling@ericsson.com