### PR TITLE
Add setCredential method that sets Authorization header.

### DIFF
--- a/src/main/java/com/ericsson/eiffelcommons/JenkinsManager.java
+++ b/src/main/java/com/ericsson/eiffelcommons/JenkinsManager.java
@@ -108,7 +108,7 @@ public class JenkinsManager {
                    .addHeader("Authorization", "Basic " + encoding)
                    .addHeader("Content-type", MediaType.APPLICATION_XML)
                    .addHeader("Jenkins-Crumb", crumb)
-                   .addParam("name", jobName)
+                   .addParameter("name", jobName)
                    .setBody(jobXmlData)
                    .setEndpoint("/createItem");
 
@@ -306,8 +306,8 @@ public class JenkinsManager {
         HttpRequest httpRequest = new HttpRequest(HttpMethod.GET);
         httpRequest.setBaseUrl(jenkinsBaseUrl)
                    .addHeader("Authorization", "Basic " + encoding)
-                   .addParam("depth", "1")
-                   .addParam("wrapper", "plugins")
+                   .addParameter("depth", "1")
+                   .addParameter("wrapper", "plugins")
                    .setEndpoint("/pluginManager/api/json");
 
         ResponseEntity response = httpRequest.performRequest();
@@ -438,7 +438,7 @@ public class JenkinsManager {
         httpRequest.setBaseUrl(jenkinsBaseUrl)
                    .addHeader("Authorization", "Basic " + encoding)
                    .addHeader("Content-type", mediatype)
-                   .addParam("token", jobToken)
+                   .addParameter("token", jobToken)
                    .setEndpoint(endpoint);
 
         ResponseEntity response = httpRequest.performRequest();

--- a/src/main/java/com/ericsson/eiffelcommons/utils/HttpRequest.java
+++ b/src/main/java/com/ericsson/eiffelcommons/utils/HttpRequest.java
@@ -267,13 +267,12 @@ public class HttpRequest {
     /**
      * Function that sets the Authorization header of the http request.
      *
-     * @param httpRequest
      * @param username
      * @param password
      * @return
      * @throws UnsupportedEncodingException
      */
-    public HttpRequest setCredentials(String username, String password)
+    public HttpRequest setBasicAuth(String username, String password)
             throws UnsupportedEncodingException {
         String auth = String.format("%s:%s", username, password);
         String encodedAuth = new String(Base64.encodeBase64(auth.getBytes()), "UTF-8");

--- a/src/main/java/com/ericsson/eiffelcommons/utils/HttpRequest.java
+++ b/src/main/java/com/ericsson/eiffelcommons/utils/HttpRequest.java
@@ -18,13 +18,16 @@ package com.ericsson.eiffelcommons.utils;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.io.FileUtils;
 import org.apache.http.Header;
+import org.apache.http.HttpHeaders;
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.methods.HttpDelete;
 import org.apache.http.client.methods.HttpEntityEnclosingRequestBase;
@@ -262,6 +265,23 @@ public class HttpRequest {
             throw new IOException(message);
         }
         return setBody(fileContent, contentType);
+    }
+
+    /**
+     * Function that sets the Authorization header of the http request.
+     *
+     * @param httpRequest
+     * @param username
+     * @param password
+     * @return
+     * @throws UnsupportedEncodingException
+     */
+    public HttpRequest setCredentials(HttpRequest httpRequest, String username,
+            String password) throws UnsupportedEncodingException {
+        String auth = username + ":" + password;
+        String encodedAuth = new String(Base64.encodeBase64(auth.getBytes()), "UTF-8");
+        request.addHeader(HttpHeaders.AUTHORIZATION, "Basic " + encodedAuth);
+        return this;
     }
 
     /**

--- a/src/main/java/com/ericsson/eiffelcommons/utils/HttpRequest.java
+++ b/src/main/java/com/ericsson/eiffelcommons/utils/HttpRequest.java
@@ -191,7 +191,7 @@ public class HttpRequest {
      */
     public void addParameters(Map<String, String> parameters) {
         for (Map.Entry<String, String> entry : parameters.entrySet()) {
-            addParam(entry.getKey(), entry.getValue());
+            addParameter(entry.getKey(), entry.getValue());
         }
     }
 
@@ -204,7 +204,7 @@ public class HttpRequest {
      *            :: the value of the parameter
      * @return HttpRequest
      */
-    public HttpRequest addParam(String key, String value) {
+    public HttpRequest addParameter(String key, String value) {
         params.put(key, value);
         return this;
     }

--- a/src/main/java/com/ericsson/eiffelcommons/utils/HttpRequest.java
+++ b/src/main/java/com/ericsson/eiffelcommons/utils/HttpRequest.java
@@ -84,7 +84,7 @@ public class HttpRequest {
     }
 
     private void initExecutor(boolean persistentClient) {
-        if(persistentClient) {
+        if (persistentClient) {
             executor = HttpExecutor.getInstance();
         } else {
             executor = new HttpExecutor();
@@ -93,6 +93,7 @@ public class HttpRequest {
 
     /**
      * Sets the http method for this request object
+     *
      * @param method
      */
     public HttpRequest setHttpMethod(HttpMethod method) {
@@ -116,6 +117,7 @@ public class HttpRequest {
 
     /**
      * Gets the base url(not including endpoint) for example: http://localhost:8080
+     *
      * @return String
      */
     public String getBaseUrl() {
@@ -124,6 +126,7 @@ public class HttpRequest {
 
     /**
      * Sets the base url(not including endpoint) for example: http://localhost:8080
+     *
      * @param baseUrl
      */
     public HttpRequest setBaseUrl(String baseUrl) {
@@ -150,18 +153,18 @@ public class HttpRequest {
     /**
      * Function the adds a header to the http request.
      *
-     * @param key
-     *            :: the key of the header
-     * @param value
-     *            :: the value of the header
+     * @param key   :: the key of the header
+     * @param value :: the value of the header
      * @return HttpRequest
      */
     public HttpRequest addHeader(String key, String value) {
         request.addHeader(key, value);
         return this;
     }
+
     /**
-     * Function that overwrites the first header with the same name. The new header will be appended to the end of the list, if no header with the given name can be found.
+     * Function that overwrites the first header with the same name. The new header will be appended
+     * to the end of the list, if no header with the given name can be found.
      *
      * @param key
      * @param value
@@ -176,8 +179,7 @@ public class HttpRequest {
     /**
      * Takes a header key as input and removes that key and value from the list of headers.
      *
-     * @param headerKey
-     *            :: the header to remove
+     * @param headerKey :: the header to remove
      */
     public void removeHeader(String headerKey) {
         request.removeHeaders(headerKey);
@@ -186,8 +188,7 @@ public class HttpRequest {
     /**
      * Function that adds multiple parameters to the http request.
      *
-     * @param parameters
-     *            :: List<NameValuePair>
+     * @param parameters :: List<NameValuePair>
      */
     public void addParameters(Map<String, String> parameters) {
         for (Map.Entry<String, String> entry : parameters.entrySet()) {
@@ -198,10 +199,8 @@ public class HttpRequest {
     /**
      * Function that adds a parameter to the http request.
      *
-     * @param key
-     *            :: the key of the parameter
-     * @param value
-     *            :: the value of the parameter
+     * @param key   :: the key of the parameter
+     * @param value :: the value of the parameter
      * @return HttpRequest
      */
     public HttpRequest addParameter(String key, String value) {
@@ -212,8 +211,7 @@ public class HttpRequest {
     /**
      * Function that sets the body of the http request with a chosen content type.
      *
-     * @param body
-     *            :: String input
+     * @param body :: String input
      * @return HTTPRequest
      */
     public HttpRequest setBody(String body, ContentType contentType) {
@@ -224,8 +222,7 @@ public class HttpRequest {
     /**
      * Function that sets the body of the http request with default content type(text/plain).
      *
-     * @param body
-     *            :: String input
+     * @param body :: String input
      * @return HTTPRequest
      */
     public HttpRequest setBody(String body) {
@@ -234,10 +231,10 @@ public class HttpRequest {
     }
 
     /**
-     * Function that sets the body of the http request with default value of content type (text/plain).
+     * Function that sets the body of the http request with default value of content type
+     * (text/plain).
      *
-     * @param file
-     *            :: File input
+     * @param file :: File input
      * @return HTTPRequest
      * @throws IOException
      */
@@ -249,8 +246,7 @@ public class HttpRequest {
     /**
      * Function that sets the body of the http request with a chosen content type.
      *
-     * @param file
-     *            :: File input
+     * @param file :: File input
      * @param type
      * @return HTTPRequest
      * @throws IOException
@@ -260,7 +256,8 @@ public class HttpRequest {
         try {
             fileContent = FileUtils.readFileToString(file, "UTF-8");
         } catch (IOException e) {
-            final String message = "Failed to read the Request body file:" + file.getPath() + ". Message: "
+            final String message = "Failed to read the Request body file:" + file.getPath()
+                    + ". Message: "
                     + e.getMessage();
             throw new IOException(message);
         }
@@ -276,11 +273,11 @@ public class HttpRequest {
      * @return
      * @throws UnsupportedEncodingException
      */
-    public HttpRequest setCredentials(HttpRequest httpRequest, String username,
-            String password) throws UnsupportedEncodingException {
-        String auth = username + ":" + password;
+    public HttpRequest setCredentials(String username, String password)
+            throws UnsupportedEncodingException {
+        String auth = String.format("%s:%s", username, password);
         String encodedAuth = new String(Base64.encodeBase64(auth.getBytes()), "UTF-8");
-        request.addHeader(HttpHeaders.AUTHORIZATION, "Basic " + encodedAuth);
+        params.put(HttpHeaders.AUTHORIZATION, "Basic " + encodedAuth);
         return this;
     }
 
@@ -292,7 +289,8 @@ public class HttpRequest {
      * @throws IOException
      * @throws ClientProtocolException
      */
-    public ResponseEntity performRequest() throws URISyntaxException, ClientProtocolException, IOException {
+    public ResponseEntity performRequest()
+            throws URISyntaxException, ClientProtocolException, IOException {
         URIBuilder builder = createURIBuilder();
         builder = addParametersToURIBuilder(builder);
         request.setURI(builder.build());
@@ -334,7 +332,7 @@ public class HttpRequest {
      * @throws URISyntaxException
      */
     private URIBuilder createURIBuilder() throws URISyntaxException {
-        if(endpoint.startsWith("/")) {
+        if (endpoint.startsWith("/")) {
             return new URIBuilder(baseUrl + endpoint);
         } else {
             return new URIBuilder(baseUrl + "/" + endpoint);
@@ -347,7 +345,7 @@ public class HttpRequest {
      * @return HttpRequest
      */
     private String trimBaseUrl(String baseUrl) {
-        if(baseUrl.endsWith("/")) {
+        if (baseUrl.endsWith("/")) {
             baseUrl = baseUrl.substring(0, baseUrl.length() - 1);
         }
 

--- a/src/test/java/com/ericsson/eiffelcommons/Utilstest/HttpRequestTest.java
+++ b/src/test/java/com/ericsson/eiffelcommons/Utilstest/HttpRequestTest.java
@@ -2,9 +2,12 @@ package com.ericsson.eiffelcommons.Utilstest;
 
 import static org.junit.Assert.assertEquals;
 
+import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.net.URISyntaxException;
 
+import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.utils.URIBuilder;
 import org.junit.Test;
 
@@ -13,30 +16,43 @@ import com.ericsson.eiffelcommons.utils.HttpRequest.HttpMethod;
 
 public class HttpRequestTest {
     @Test
-    public void testBuildingOfURI() throws NoSuchFieldException, SecurityException, IllegalAccessException, IllegalArgumentException, InvocationTargetException, NoSuchMethodException {
+    public void testBuildingOfURI()
+            throws NoSuchFieldException, SecurityException, IllegalAccessException,
+            IllegalArgumentException, InvocationTargetException, NoSuchMethodException,
+            URISyntaxException, ClientProtocolException, IOException {
         String expectedURI = "http://something.com/testing/test/";
-        HttpRequest request= new HttpRequest(HttpMethod.POST);
-        Method method = request.getClass().getDeclaredMethod("createURIBuilder");
-        method.setAccessible(true);
+        String expectedAuthParam = "Authorization=Basic dXNlcm5hbWU6cGFzc3dvcmQ=";
+        HttpRequest request = new HttpRequest(HttpMethod.POST);
+        Method createURIBuilder = HttpRequest.class.getDeclaredMethod("createURIBuilder");
+        Method addParametersToURIBuilder = HttpRequest.class.getDeclaredMethod(
+                "addParametersToURIBuilder", URIBuilder.class);
+        createURIBuilder.setAccessible(true);
+        addParametersToURIBuilder.setAccessible(true);
 
         request.setBaseUrl("http://something.com");
         request.setEndpoint("/testing/test/");
-        URIBuilder builder = (URIBuilder) method.invoke(request);
+        URIBuilder builder = (URIBuilder) createURIBuilder.invoke(request);
         assertEquals(expectedURI, builder.toString());
 
         request.setBaseUrl("http://something.com/");
         request.setEndpoint("/testing/test/");
-        builder = (URIBuilder) method.invoke(request);
+        builder = (URIBuilder) createURIBuilder.invoke(request);
         assertEquals(expectedURI, builder.toString());
 
         request.setBaseUrl("http://something.com/");
         request.setEndpoint("testing/test/");
-        builder = (URIBuilder) method.invoke(request);
+        builder = (URIBuilder) createURIBuilder.invoke(request);
         assertEquals(expectedURI, builder.toString());
 
         request.setBaseUrl("http://something.com");
         request.setEndpoint("testing/test/");
-        builder = (URIBuilder) method.invoke(request);
+        builder = (URIBuilder) createURIBuilder.invoke(request);
         assertEquals(expectedURI, builder.toString());
+
+        request.setCredentials("username", "password");
+        builder = (URIBuilder) createURIBuilder.invoke(request);
+        builder = (URIBuilder) addParametersToURIBuilder.invoke(request, builder);
+        String actualAuthParam = builder.getQueryParams().get(0).toString();
+        assertEquals(expectedAuthParam, actualAuthParam);
     }
 }

--- a/src/test/java/com/ericsson/eiffelcommons/Utilstest/HttpRequestTest.java
+++ b/src/test/java/com/ericsson/eiffelcommons/Utilstest/HttpRequestTest.java
@@ -49,7 +49,7 @@ public class HttpRequestTest {
         builder = (URIBuilder) createURIBuilder.invoke(request);
         assertEquals(expectedURI, builder.toString());
 
-        request.setCredentials("username", "password");
+        request.setBasicAuth("username", "password");
         builder = (URIBuilder) createURIBuilder.invoke(request);
         builder = (URIBuilder) addParametersToURIBuilder.invoke(request, builder);
         String actualAuthParam = builder.getQueryParams().get(0).toString();


### PR DESCRIPTION
### Applicable Issues

### Description of the Change
Adds the frequently used setCredentials method in http request. It was possible to do before by creating your own method that sets the Authorization header. This just makes implementing your own method unnecessary.

### Alternate Designs

### Benefits

### Possible Drawbacks

### Sign-off
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: @Christoffer-Cortes 
