### PR TITLE
Fix setBasicAuth method to actually set header instead of parameter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.ericsson</groupId>
@@ -14,39 +16,57 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
     </properties>
-    
+
     <dependencies>
         <dependency>
             <groupId>javax.ws.rs</groupId>
             <artifactId>javax.ws.rs-api</artifactId>
             <version>2.1.1</version>
         </dependency>
+
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
             <version>2.6</version>
         </dependency>
+
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>4.5.3</version>
         </dependency>
+
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.16.20</version>
             <scope>provided</scope>
         </dependency>
+
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
             <version>20180130</version>
         </dependency>
-         <!-- https://mvnrepository.com/artifact/junit/junit -->
+
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>3.1.0</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-reflect</artifactId>
+            <version>2.0.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/com/ericsson/eiffelcommons/utils/HttpRequest.java
+++ b/src/main/java/com/ericsson/eiffelcommons/utils/HttpRequest.java
@@ -276,7 +276,7 @@ public class HttpRequest {
             throws UnsupportedEncodingException {
         String auth = String.format("%s:%s", username, password);
         String encodedAuth = new String(Base64.encodeBase64(auth.getBytes()), "UTF-8");
-        params.put(HttpHeaders.AUTHORIZATION, "Basic " + encodedAuth);
+        addHeader(HttpHeaders.AUTHORIZATION, "Basic " + encodedAuth);
         return this;
     }
 

--- a/src/test/java/com/ericsson/eiffelcommons/Utilstest/HttpRequestTest.java
+++ b/src/test/java/com/ericsson/eiffelcommons/Utilstest/HttpRequestTest.java
@@ -2,57 +2,46 @@ package com.ericsson.eiffelcommons.Utilstest;
 
 import static org.junit.Assert.assertEquals;
 
-import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.net.URISyntaxException;
-
-import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.client.utils.URIBuilder;
 import org.junit.Test;
+import org.powermock.reflect.Whitebox;
 
 import com.ericsson.eiffelcommons.utils.HttpRequest;
 import com.ericsson.eiffelcommons.utils.HttpRequest.HttpMethod;
 
 public class HttpRequestTest {
+    private static final String EXPECTED_URI = "http://something.com/testing/test/";
+    private static final String EXPECTED_HEADER = "Authorization: Basic dXNlcm5hbWU6cGFzc3dvcmQ=";
+
     @Test
-    public void testBuildingOfURI()
-            throws NoSuchFieldException, SecurityException, IllegalAccessException,
-            IllegalArgumentException, InvocationTargetException, NoSuchMethodException,
-            URISyntaxException, ClientProtocolException, IOException {
-        String expectedURI = "http://something.com/testing/test/";
-        String expectedAuthParam = "Authorization=Basic dXNlcm5hbWU6cGFzc3dvcmQ=";
+    public void testBuildingOfURI() throws Exception {
+
         HttpRequest request = new HttpRequest(HttpMethod.POST);
-        Method createURIBuilder = HttpRequest.class.getDeclaredMethod("createURIBuilder");
-        Method addParametersToURIBuilder = HttpRequest.class.getDeclaredMethod(
-                "addParametersToURIBuilder", URIBuilder.class);
-        createURIBuilder.setAccessible(true);
-        addParametersToURIBuilder.setAccessible(true);
 
         request.setBaseUrl("http://something.com");
         request.setEndpoint("/testing/test/");
-        URIBuilder builder = (URIBuilder) createURIBuilder.invoke(request);
-        assertEquals(expectedURI, builder.toString());
+        URIBuilder builder = (URIBuilder) Whitebox.invokeMethod(request, "createURIBuilder");
+        assertEquals(EXPECTED_URI, builder.toString());
 
         request.setBaseUrl("http://something.com/");
         request.setEndpoint("/testing/test/");
-        builder = (URIBuilder) createURIBuilder.invoke(request);
-        assertEquals(expectedURI, builder.toString());
+        builder = (URIBuilder) Whitebox.invokeMethod(request, "createURIBuilder");
+        assertEquals(EXPECTED_URI, builder.toString());
 
         request.setBaseUrl("http://something.com/");
         request.setEndpoint("testing/test/");
-        builder = (URIBuilder) createURIBuilder.invoke(request);
-        assertEquals(expectedURI, builder.toString());
+        builder = (URIBuilder) Whitebox.invokeMethod(request, "createURIBuilder");
+        assertEquals(EXPECTED_URI, builder.toString());
 
         request.setBaseUrl("http://something.com");
         request.setEndpoint("testing/test/");
-        builder = (URIBuilder) createURIBuilder.invoke(request);
-        assertEquals(expectedURI, builder.toString());
+        builder = (URIBuilder) Whitebox.invokeMethod(request, "createURIBuilder");
+        assertEquals(EXPECTED_URI, builder.toString());
 
         request.setBasicAuth("username", "password");
-        builder = (URIBuilder) createURIBuilder.invoke(request);
-        builder = (URIBuilder) addParametersToURIBuilder.invoke(request, builder);
-        String actualAuthParam = builder.getQueryParams().get(0).toString();
-        assertEquals(expectedAuthParam, actualAuthParam);
+        HttpRequestBase client = Whitebox.getInternalState(request, "request");
+        String actualAuthHeader = client.getAllHeaders()[0].toString();
+        assertEquals(EXPECTED_HEADER, actualAuthHeader);
     }
 }


### PR DESCRIPTION
### Applicable Issues

### Description of the Change
As the tile of the PR describes.
No one noticed in https://github.com/eiffel-community/eiffel-commons/pull/26 that I was actually setting basic auth as a parameter instead of the header.

### Alternate Designs

### Benefits

### Possible Drawbacks

### Sign-off
Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.

Signed-off-by: @Christoffer-Cortes 
